### PR TITLE
fix: 배포 자동화 스크립트의 포트번호 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,4 +59,4 @@ jobs:
             docker stop cstar-backend-container || true
             docker rm cstar-backend-container || true
             docker pull ${{ steps.login-ecr.outputs.registry }}/cstar-backend-server:latest
-            docker run -d --name cstar-backend-container -p 8080:8080 ${{ steps.login-ecr.outputs.registry }}/cstar-backend-server:latest
+            docker run -d --name cstar-backend-container -p 80:8080 ${{ steps.login-ecr.outputs.registry }}/cstar-backend-server:latest


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #5 

## 📝 작업한 내용
- [x] 도커 컨테이너 포트를 8080:8080에서 80:8080 으로 변경하여 서버에 들어오는 요청을 컨테이너의 8080포트로 연결

## 💬 논의하고 싶은 내용
- x
