### PR TITLE
feat: 테이블에 매칭되는 jpa 엔티티 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("org.springframework.boot") version "3.3.2"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "11.4.0"
+    kotlin("plugin.jpa") version "1.9.24"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
 }

--- a/src/main/kotlin/yjh/cstar/config/JpaConfig.kt
+++ b/src/main/kotlin/yjh/cstar/config/JpaConfig.kt
@@ -1,0 +1,8 @@
+package yjh.cstar.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@EnableJpaAuditing
+@Configuration
+class JpaConfig

--- a/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameEntity.kt
+++ b/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameEntity.kt
@@ -1,0 +1,46 @@
+package yjh.cstar.game.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "game")
+@Entity
+class GameEntity(
+    @Id
+    @Column(name = "game_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "room_id", nullable = false)
+    private val roomId: Long,
+
+    @Column(name = "member_id", nullable = false)
+    private val winnerId: Long,
+
+    @Column(name = "total_quiz_count", nullable = false)
+    private val totalQuizCount: Int,
+
+    @Column(name = "started_at", nullable = false)
+    private var startedAt: LocalDateTime?,
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private var createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private var updatedAt: LocalDateTime?,
+
+    @Column(name = "deleted_at")
+    private val deletedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.game.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameJpaRepository : JpaRepository<GameEntity, Long>

--- a/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameResultEntity.kt
+++ b/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameResultEntity.kt
@@ -1,0 +1,49 @@
+package yjh.cstar.game.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "member_game_result")
+@Entity
+class GameResultEntity(
+    @Id
+    @Column(name = "member_game_result_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "game_id", nullable = false)
+    private val gameId: Long,
+
+    @Column(name = "member_id", nullable = false)
+    private val playerId: Long,
+
+    @Column(name = "total_count", nullable = false)
+    private val totalCount: Int,
+
+    @Column(name = "correct_count", nullable = false)
+    private val correctCount: Int,
+
+    @Column(name = "ranking", nullable = false)
+    private val ranking: Int,
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private var createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private var updatedAt: LocalDateTime?,
+
+    @Column(name = "deleted_at")
+    private val deletedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameResultJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/game/infrastructure/jpa/GameResultJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.game.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameResultJpaRepository : JpaRepository<GameResultEntity, Long>

--- a/src/main/kotlin/yjh/cstar/member/infrastructure/jpa/MemberEntity.kt
+++ b/src/main/kotlin/yjh/cstar/member/infrastructure/jpa/MemberEntity.kt
@@ -1,0 +1,43 @@
+package yjh.cstar.member.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "member")
+@Entity
+class MemberEntity(
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "email", nullable = false)
+    private val email: String,
+
+    @Column(name = "password", nullable = false)
+    private val password: String,
+
+    @Column(name = "nickname", nullable = false)
+    private val nickname: String,
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private var createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private var updatedAt: LocalDateTime?,
+
+    @Column(name = "deleted_at")
+    private val deletedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/yjh/cstar/member/infrastructure/jpa/MemberJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/member/infrastructure/jpa/MemberJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.member.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberJpaRepository : JpaRepository<MemberEntity, Long>

--- a/src/main/kotlin/yjh/cstar/quiz/domain/Category.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/domain/Category.kt
@@ -1,0 +1,9 @@
+package yjh.cstar.quiz.domain
+
+enum class Category {
+    NETWORK,
+    ALGORITHM,
+    OPERATING_SYSTEM,
+    DATABASE,
+    DESIGN_PATTERN,
+}

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/domain/Category.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/domain/Category.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.quiz.infrastructure.domain
+
+enum class Category {
+    NETWORK,
+}

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/domain/Category.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/domain/Category.kt
@@ -1,5 +1,0 @@
-package yjh.cstar.quiz.infrastructure.domain
-
-enum class Category {
-    NETWORK,
-}

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/GameQuizEntity.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/GameQuizEntity.kt
@@ -1,0 +1,23 @@
+package yjh.cstar.quiz.infrastructure.jpa
+
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Table
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.io.Serializable
+
+@Embeddable
+class GameQuizId(
+    val gameId: Long = 0,
+    val quizId: Long = 0,
+) : Serializable
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "game_quiz")
+@Entity
+class GameQuizEntity(
+    @EmbeddedId
+    val id: GameQuizId,
+)

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/GameQuizJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/GameQuizJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.quiz.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameQuizJpaRepository : JpaRepository<GameQuizEntity, GameQuizId>

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizEntity.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizEntity.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Table
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import yjh.cstar.quiz.infrastructure.domain.Category
+import yjh.cstar.quiz.domain.Category
 import java.time.LocalDateTime
 
 @EntityListeners(AuditingEntityListener::class)

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizEntity.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizEntity.kt
@@ -1,0 +1,47 @@
+package yjh.cstar.quiz.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import yjh.cstar.quiz.infrastructure.domain.Category
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "quiz")
+@Entity
+class QuizEntity(
+    @Id
+    @Column(name = "quiz_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "member_id", nullable = false)
+    private val writerId: Long,
+
+    @Column(name = "question", nullable = false)
+    val question: String,
+
+    @Column(name = "answer", nullable = false)
+    val answer: String,
+
+    @Column(name = "category", nullable = false)
+    val category: Category,
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private var createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private var updatedAt: LocalDateTime?,
+
+    @Column(name = "deleted_at")
+    private val deletedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/quiz/infrastructure/jpa/QuizJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.quiz.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface QuizJpaRepository : JpaRepository<QuizEntity, Long>

--- a/src/main/kotlin/yjh/cstar/room/domain/RoomStatus.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/RoomStatus.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.room.domain
+
+enum class RoomStatus {
+    WAITING, RUNNING
+}

--- a/src/main/kotlin/yjh/cstar/room/domain/RoomStatus.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/RoomStatus.kt
@@ -1,5 +1,5 @@
 package yjh.cstar.room.domain
 
 enum class RoomStatus {
-    WAITING, RUNNING
+    WAITING, IN_PROGRESS
 }

--- a/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomEntity.kt
+++ b/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomEntity.kt
@@ -1,0 +1,44 @@
+package yjh.cstar.room.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import yjh.cstar.room.domain.RoomStatus
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "room")
+@Entity
+class RoomEntity(
+    @Id
+    @Column(name = "room_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "max_capacity", nullable = false)
+    private val maxCapacity: Int,
+
+    @Column(name = "curr_capacity", nullable = false)
+    private val currCapacity: Int,
+
+    @Column(name = "status", nullable = false)
+    private val status: RoomStatus,
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private var createdAt: LocalDateTime?,
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private var updatedAt: LocalDateTime?,
+
+    @Column(name = "deleted_at")
+    private val deletedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJoinEntity.kt
+++ b/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJoinEntity.kt
@@ -1,0 +1,30 @@
+package yjh.cstar.room.infrastructure.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "room_join")
+@Entity
+class RoomJoinEntity(
+    @Id
+    @Column(name = "room_join_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(name = "room_id", nullable = false)
+    private val roomId: Long,
+
+    @Column(name = "member_id", nullable = false)
+    private val playerId: Long,
+
+    @Column(name = "joined_at", nullable = false)
+    private var joinedAt: LocalDateTime?,
+)

--- a/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJoinJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJoinJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.room.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RoomJoinJpaRepository : JpaRepository<RoomJoinEntity, Long>

--- a/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJpaRepository.kt
+++ b/src/main/kotlin/yjh/cstar/room/infrastructure/jpa/RoomJpaRepository.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.room.infrastructure.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RoomJpaRepository : JpaRepository<RoomEntity, Long>

--- a/src/test/kotlin/yjh/cstar/CstarApplicationTests.kt
+++ b/src/test/kotlin/yjh/cstar/CstarApplicationTests.kt
@@ -1,13 +1,7 @@
 package yjh.cstar
 
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.jdbc.Sql
 import kotlin.test.Test
 
-@ActiveProfiles("local-test") // 어떤 applicaion.yml 파일을 사용할지 선택
-@Sql(value = ["file:src/main/resources/db/init_schema.sql"])
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CstarApplicationTests : IntegrationTest() {
 
     @Test

--- a/src/test/kotlin/yjh/cstar/CstarApplicationTests.kt
+++ b/src/test/kotlin/yjh/cstar/CstarApplicationTests.kt
@@ -1,7 +1,13 @@
 package yjh.cstar
 
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.jdbc.Sql
 import kotlin.test.Test
 
+@ActiveProfiles("local-test") // 어떤 applicaion.yml 파일을 사용할지 선택
+@Sql(value = ["file:src/main/resources/db/init_schema.sql"])
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CstarApplicationTests : IntegrationTest() {
 
     @Test

--- a/src/test/kotlin/yjh/cstar/IntegrationTest.kt
+++ b/src/test/kotlin/yjh/cstar/IntegrationTest.kt
@@ -7,6 +7,5 @@ import org.springframework.transaction.annotation.Transactional
 
 @Transactional
 @ActiveProfiles("local-test")
-@Sql(value = ["file:src/main/resources/db/init_schema.sql"])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class IntegrationTest

--- a/src/test/kotlin/yjh/cstar/IntegrationTest.kt
+++ b/src/test/kotlin/yjh/cstar/IntegrationTest.kt
@@ -2,7 +2,6 @@ package yjh.cstar
 
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.jdbc.Sql
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -12,6 +12,12 @@ import org.springframework.test.context.jdbc.Sql
 import yjh.cstar.config.JpaConfig
 import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
+import yjh.cstar.room.domain.RoomStatus
+import yjh.cstar.room.infrastructure.jpa.RoomEntity
+import yjh.cstar.room.infrastructure.jpa.RoomJoinEntity
+import yjh.cstar.room.infrastructure.jpa.RoomJoinJpaRepository
+import yjh.cstar.room.infrastructure.jpa.RoomJpaRepository
+import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -25,6 +31,12 @@ class JpaTest {
 
     @Autowired
     private lateinit var memberJpaRepository: MemberJpaRepository
+
+    @Autowired
+    private lateinit var roomJpaRepository: RoomJpaRepository
+
+    @Autowired
+    private lateinit var roomJoinJpaRepository: RoomJoinJpaRepository
 
     @DisplayName("Member Entity 연결 테스트")
     @Test
@@ -47,6 +59,52 @@ class JpaTest {
         assertAll(
             { assertNotNull(members) },
             { assertEquals(1, members.size) }
+        )
+    }
+
+    @DisplayName("Room Entity 연결 테스트")
+    @Test
+    fun test2() {
+        // given
+        roomJpaRepository.save(
+            RoomEntity(
+                maxCapacity = 5,
+                currCapacity = 3,
+                status = RoomStatus.WAITING,
+                createdAt = null,
+                updatedAt = null
+            )
+        )
+
+        // when
+        val rooms = roomJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(rooms) },
+            { assertEquals(1, rooms.size) }
+        )
+    }
+
+    @DisplayName("RoomJoin Entity 연결 테스트")
+    @Test
+    fun test3() {
+        // given
+        roomJoinJpaRepository.save(
+            RoomJoinEntity(
+                roomId = 1L,
+                playerId = 1L,
+                joinedAt = LocalDateTime.now()
+            )
+        )
+
+        // when
+        val roomJoins = roomJoinJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(roomJoins) },
+            { assertEquals(1, roomJoins.size) }
         )
     }
 }

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -1,0 +1,52 @@
+package yjh.cstar.jpa
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.jdbc.Sql
+import yjh.cstar.config.JpaConfig
+import yjh.cstar.member.infrastructure.jpa.MemberEntity
+import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ActiveProfiles("local-test")
+@Import(JpaConfig::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql(value = ["file:src/main/resources/db/init_schema.sql"])
+@DisplayName("JPA 연결 테스트")
+@DataJpaTest
+class JpaTest {
+
+    @Autowired
+    private lateinit var memberJpaRepository: MemberJpaRepository
+
+    @DisplayName("Member Entity 연결 테스트")
+    @Test
+    fun test1() {
+        // given
+        memberJpaRepository.save(
+            MemberEntity(
+                email = "email",
+                password = "password",
+                nickname = "nickname",
+                createdAt = null,
+                updatedAt = null
+            )
+        )
+
+        // when
+        val members = memberJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(members) },
+            { assertEquals(1, members.size) }
+        )
+    }
+}

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -10,6 +10,10 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import yjh.cstar.config.JpaConfig
+import yjh.cstar.game.infrastructure.jpa.GameEntity
+import yjh.cstar.game.infrastructure.jpa.GameJpaRepository
+import yjh.cstar.game.infrastructure.jpa.GameResultEntity
+import yjh.cstar.game.infrastructure.jpa.GameResultJpaRepository
 import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
 import yjh.cstar.room.domain.RoomStatus
@@ -37,6 +41,12 @@ class JpaTest {
 
     @Autowired
     private lateinit var roomJoinJpaRepository: RoomJoinJpaRepository
+
+    @Autowired
+    private lateinit var gameJpaRepository: GameJpaRepository
+
+    @Autowired
+    private lateinit var gameResultJpaRepository: GameResultJpaRepository
 
     @DisplayName("Member Entity 연결 테스트")
     @Test
@@ -105,6 +115,57 @@ class JpaTest {
         assertAll(
             { assertNotNull(roomJoins) },
             { assertEquals(1, roomJoins.size) }
+        )
+    }
+
+    @DisplayName("Game Entity 연결 테스트")
+    @Test
+    fun test4() {
+        // given
+        gameJpaRepository.save(
+            GameEntity(
+                roomId = 1L,
+                winnerId = 1L,
+                totalQuizCount = 5,
+                startedAt = LocalDateTime.now(),
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            )
+        )
+
+        // when
+        val games = gameJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(games) },
+            { assertEquals(1, games.size) }
+        )
+    }
+
+    @DisplayName("GameResult Entity 연결 테스트")
+    @Test
+    fun test5() {
+        // given
+        gameResultJpaRepository.save(
+            GameResultEntity(
+                gameId = 1L,
+                playerId = 1L,
+                totalCount = 5,
+                correctCount = 5,
+                ranking = 1,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            )
+        )
+
+        // when
+        val gameResults = gameResultJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(gameResults) },
+            { assertEquals(1, gameResults.size) }
         )
     }
 }

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -15,7 +15,7 @@ import yjh.cstar.game.infrastructure.jpa.GameResultEntity
 import yjh.cstar.game.infrastructure.jpa.GameResultJpaRepository
 import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
-import yjh.cstar.quiz.infrastructure.domain.Category
+import yjh.cstar.quiz.domain.Category
 import yjh.cstar.quiz.infrastructure.jpa.GameQuizEntity
 import yjh.cstar.quiz.infrastructure.jpa.GameQuizId
 import yjh.cstar.quiz.infrastructure.jpa.GameQuizJpaRepository

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -4,12 +4,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.jdbc.Sql
 import yjh.cstar.config.JpaConfig
 import yjh.cstar.game.infrastructure.jpa.GameEntity
 import yjh.cstar.game.infrastructure.jpa.GameJpaRepository
@@ -33,10 +31,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 @ActiveProfiles("local-test")
-@Import(JpaConfig::class)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Sql(value = ["file:src/main/resources/db/init_schema.sql"])
 @DisplayName("JPA 연결 테스트")
+@Import(JpaConfig::class)
 @DataJpaTest
 class JpaTest {
 

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import yjh.cstar.config.JpaConfig
@@ -16,6 +17,12 @@ import yjh.cstar.game.infrastructure.jpa.GameResultEntity
 import yjh.cstar.game.infrastructure.jpa.GameResultJpaRepository
 import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
+import yjh.cstar.quiz.infrastructure.domain.Category
+import yjh.cstar.quiz.infrastructure.jpa.GameQuizEntity
+import yjh.cstar.quiz.infrastructure.jpa.GameQuizId
+import yjh.cstar.quiz.infrastructure.jpa.GameQuizJpaRepository
+import yjh.cstar.quiz.infrastructure.jpa.QuizEntity
+import yjh.cstar.quiz.infrastructure.jpa.QuizJpaRepository
 import yjh.cstar.room.domain.RoomStatus
 import yjh.cstar.room.infrastructure.jpa.RoomEntity
 import yjh.cstar.room.infrastructure.jpa.RoomJoinEntity
@@ -47,6 +54,12 @@ class JpaTest {
 
     @Autowired
     private lateinit var gameResultJpaRepository: GameResultJpaRepository
+
+    @Autowired
+    private lateinit var quizJpaRepository: QuizJpaRepository
+
+    @Autowired
+    private lateinit var gameQuizJpaRepository: GameQuizJpaRepository
 
     @DisplayName("Member Entity 연결 테스트")
     @Test
@@ -167,5 +180,47 @@ class JpaTest {
             { assertNotNull(gameResults) },
             { assertEquals(1, gameResults.size) }
         )
+    }
+
+    @DisplayName("Quiz Entity 연결 테스트")
+    @Test
+    fun test6() {
+        // given
+        quizJpaRepository.save(
+            QuizEntity(
+                writerId = 1L,
+                question = "question",
+                answer = "answer",
+                category = Category.NETWORK,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            )
+        )
+
+        // when
+        val quizzes = quizJpaRepository.findAll()
+
+        // then
+        assertAll(
+            { assertNotNull(quizzes) },
+            { assertEquals(1, quizzes.size) }
+        )
+    }
+
+    @DisplayName("GameQuiz Entity 연결 테스트")
+    @Test
+    fun test7() {
+        // given
+        val gameQuizId = GameQuizId(1L, 1L)
+        gameQuizJpaRepository.save(GameQuizEntity(id = gameQuizId))
+
+        // when
+        val gameQuiz = gameQuizJpaRepository.findByIdOrNull(GameQuizId(1L, 1L))
+
+        // then
+        assertNotNull(gameQuiz).also {
+            assertEquals(1L, gameQuiz.id.gameId)
+            assertEquals(1L, gameQuiz.id.quizId)
+        }
     }
 }

--- a/src/test/resources/application-local-test.yml
+++ b/src/test/resources/application-local-test.yml
@@ -9,3 +9,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  test:
+    database:
+      replace: none
+  sql:
+    init:
+      mode: always
+      data-locations:
+        - file:src/main/resources/db/init_schema.sql


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #9

## 📝 작업한 내용
- [x] 아래의 테이블에 매칭되는 JPA 엔티티 구현
![image](https://github.com/user-attachments/assets/7f5a3212-7c09-4663-973e-e6f5ebbf58a6)


## 💬 논의하고 싶은 내용
- JPA의 어노테이션을 이용한 다대다 맵핑 테이블을 이용하지 않고, 직접 엔티티 클래스를 생성해서(ex GameQuizEntity)  컨트롤하도록 했습니다. 어떤방식이 더 나을까요?
