### PR TITLE
fix: Member 테이블의 email, nickname 에 unique 제약 조건 추가

### DIFF
--- a/src/main/resources/db/v2_alter_member_table_for_unique.sql
+++ b/src/main/resources/db/v2_alter_member_table_for_unique.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member ADD UNIQUE (email);
+
+ALTER TABLE member ADD UNIQUE (nickname);

--- a/src/test/kotlin/yjh/cstar/member/concurrency/MemberConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/member/concurrency/MemberConcurrencyTest.kt
@@ -1,0 +1,116 @@
+package yjh.cstar.member.concurrency
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import yjh.cstar.member.application.MemberService
+import yjh.cstar.member.domain.MemberCreateCommand
+import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+/**
+ * 주의) 별도의 스레드를 통해서 테스트 동작을 수행하기 때문에,
+ * @Transactional 를 사용하지 않아야 함(사용하면 올바르게 동작하지 않음)
+ */
+@DisplayName("[동시성 테스트] MemberService")
+@ActiveProfiles("local-test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class MemberConcurrencyTest {
+
+    @Autowired
+    private lateinit var memberService: MemberService
+
+    @Autowired
+    private lateinit var memberJpaRepository: MemberJpaRepository
+
+    @BeforeTest
+    fun clearBefore() {
+        memberJpaRepository.deleteAll()
+    }
+
+    @AfterTest
+    fun clearAfter() {
+        memberJpaRepository.deleteAll()
+    }
+
+    @Test
+    fun `회원 생성시 email 중복 동시성 테스트`() {
+        // given
+        val numberOfThreads = 10
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(numberOfThreads)
+        val executor = Executors.newFixedThreadPool(numberOfThreads)
+
+        // when
+        for (idx in 1..numberOfThreads) {
+            executor.submit {
+                try {
+                    memberService.create(
+                        MemberCreateCommand(
+                            email = "email@naver.com",
+                            password = "password",
+                            nickname = "nickname" + idx
+                        )
+                    )
+                } catch (e: Exception) {
+                    println("Error: ${e.message}")
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown() // 모든 스레드 동시에 시작
+
+        doneLatch.await() // 모든 스레드 종료 대기
+
+        executor.shutdown()
+
+        // then
+        val members = memberJpaRepository.findAll()
+        assertEquals(1, members.size) // 1개만 생성 되었어야 함.
+    }
+
+    @Test
+    fun `회원 생성시 nickname 중복 동시성 테스트`() {
+        // given
+        val numberOfThreads = 10
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(numberOfThreads)
+        val executor = Executors.newFixedThreadPool(numberOfThreads)
+
+        // when
+        for (idx in 1..numberOfThreads) {
+            executor.submit {
+                try {
+                    memberService.create(
+                        MemberCreateCommand(
+                            email = "email@naver.com" + idx,
+                            password = "password",
+                            nickname = "nickname"
+                        )
+                    )
+                } catch (e: Exception) {
+                    println("Error: ${e.message}")
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown()
+        doneLatch.await()
+
+        executor.shutdown()
+
+        // then
+        val members = memberJpaRepository.findAll()
+        assertEquals(1, members.size)
+    }
+}

--- a/src/test/resources/application-local-test.yml
+++ b/src/test/resources/application-local-test.yml
@@ -17,3 +17,4 @@ spring:
       mode: always
       data-locations:
         - file:src/main/resources/db/init_schema.sql
+        - file:src/main/resources/db/v2_alter_member_table_for_unique.sql


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #22

## 📝 작업한 내용
- [x] Member 테이블의 email, nickname 필드에 유니크 제약 조건 추가
- [x] 제약 조건 추가 쿼리에 따라 resources/db에 sql 파일 생성 및 application.yml에 적용 
- [x] 동시성 해결 확인을 위한 테스트 작성

## 💬 논의하고 싶은 내용
- 동시성 발생 확률이 낮은 요청이기 때문에 제약 조건을 추가해서 애플리케이션 단에서 예외를 처리하는 식으로 구현하였습니다. 이와 관련해서 여러 의견 듣고싶습니다!!
