### PR TITLE
feat: 방 참가 기능 구현

### DIFF
--- a/src/main/kotlin/yjh/cstar/common/BaseErrorCode.kt
+++ b/src/main/kotlin/yjh/cstar/common/BaseErrorCode.kt
@@ -44,6 +44,8 @@ enum class BaseErrorCode(
     NOT_FOUND_ROOM(HttpStatus.NOT_FOUND, 4040, "게임방을 찾을 수 없습니다"),
 
     // 409
+    NOT_IN_WAITING_STATUS(HttpStatus.CONFLICT, 4090, "게임 방이 현재 대기 상태가 아닙니다."),
+    CAPACITY_EXCEEDED(HttpStatus.CONFLICT, 4091, "게임 방의 수용 가능 인원이 초과되었습니다."),
     CONFLICT_MEMBER(HttpStatus.CONFLICT, 40910, "회원이 이미 존재합니다."),
 
     // 500

--- a/src/main/kotlin/yjh/cstar/room/application/RoomService.kt
+++ b/src/main/kotlin/yjh/cstar/room/application/RoomService.kt
@@ -1,22 +1,34 @@
 package yjh.cstar.room.application
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import yjh.cstar.common.BaseErrorCode
 import yjh.cstar.common.BaseException
 import yjh.cstar.room.application.port.RoomRepository
 import yjh.cstar.room.domain.Room
 import yjh.cstar.room.domain.RoomCreateCommand
 
+@Transactional(readOnly = true)
 @Service
 class RoomService(
     private val roomRepository: RoomRepository,
 ) {
+
+    fun retrieve(id: Long): Room {
+        return roomRepository.findByIdOrNull(id) ?: throw BaseException(BaseErrorCode.NOT_FOUND_ROOM)
+    }
+
+    @Transactional
     fun create(command: RoomCreateCommand): Long {
         val room = Room.create(command)
         return roomRepository.save(room).id
     }
 
-    fun retrieve(id: Long): Room {
-        return roomRepository.findByIdOrNull(id) ?: throw BaseException(BaseErrorCode.NOT_FOUND_ROOM)
+    @Transactional
+    fun join(roomId: Long, memberId: Long): Long {
+        val room = retrieve(roomId)
+        room.entrance()
+        roomRepository.save(room)
+        return roomId
     }
 }

--- a/src/main/kotlin/yjh/cstar/room/domain/Room.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/Room.kt
@@ -38,5 +38,4 @@ class Room(
             throw BaseException(BaseErrorCode.NOT_IN_WAITING_STATUS)
         }
     }
-
 }

--- a/src/main/kotlin/yjh/cstar/room/domain/Room.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/Room.kt
@@ -1,11 +1,13 @@
 package yjh.cstar.room.domain
 
+import yjh.cstar.common.BaseErrorCode
+import yjh.cstar.common.BaseException
 import java.time.LocalDateTime
 
 class Room(
     val id: Long = 0,
     val maxCapacity: Int,
-    val currCapacity: Int = 0,
+    var currCapacity: Int = 0,
     val status: RoomStatus = RoomStatus.WAITING,
     var createdAt: LocalDateTime? = null,
     var updatedAt: LocalDateTime? = null,
@@ -18,4 +20,23 @@ class Room(
             )
         }
     }
+
+    fun entrance() {
+        checkWaitingStatus()
+        checkCapacity()
+        currCapacity++
+    }
+
+    private fun checkCapacity() {
+        require(currCapacity <= maxCapacity - 1) {
+            throw BaseException(BaseErrorCode.CAPACITY_EXCEEDED)
+        }
+    }
+
+    private fun checkWaitingStatus() {
+        require(status == RoomStatus.WAITING) {
+            throw BaseException(BaseErrorCode.NOT_IN_WAITING_STATUS)
+        }
+    }
+
 }

--- a/src/main/kotlin/yjh/cstar/room/presentation/RoomController.kt
+++ b/src/main/kotlin/yjh/cstar/room/presentation/RoomController.kt
@@ -40,6 +40,8 @@ class RoomController(
         @PathVariable("id") roomId: Long,
         @RequestBody request: RoomJoinRequest,
     ): ResponseEntity<Response<Long>> {
-        return ResponseEntity.ok(Response(data = roomService.join(roomId, request.memberId)))
+        synchronized(this) {
+            return ResponseEntity.ok(Response(data = roomService.join(roomId, request.memberId)))
+        }
     }
 }

--- a/src/main/kotlin/yjh/cstar/room/presentation/RoomController.kt
+++ b/src/main/kotlin/yjh/cstar/room/presentation/RoomController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 import yjh.cstar.common.Response
 import yjh.cstar.room.application.RoomService
 import yjh.cstar.room.presentation.request.RoomCreateRequest
+import yjh.cstar.room.presentation.request.RoomJoinRequest
 import yjh.cstar.room.presentation.request.toCommand
 import yjh.cstar.room.presentation.response.RoomResponse
 
@@ -32,5 +33,13 @@ class RoomController(
     ): ResponseEntity<Response<RoomResponse>> {
         val response = RoomResponse.from(roomService.retrieve(id))
         return ResponseEntity.ok(Response(data = response))
+    }
+
+    @PostMapping("/rooms/{id}")
+    fun join(
+        @PathVariable("id") roomId: Long,
+        @RequestBody request: RoomJoinRequest,
+    ): ResponseEntity<Response<Long>> {
+        return ResponseEntity.ok(Response(data = roomService.join(roomId, request.memberId)))
     }
 }

--- a/src/main/kotlin/yjh/cstar/room/presentation/request/RoomJoinRequest.kt
+++ b/src/main/kotlin/yjh/cstar/room/presentation/request/RoomJoinRequest.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.room.presentation.request
+
+data class RoomJoinRequest(
+    val memberId: Long,
+)

--- a/src/test/kotlin/yjh/cstar/room/application/RoomServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/application/RoomServiceTest.kt
@@ -57,7 +57,7 @@ class RoomServiceTest : IntegrationTest() {
                 currCapacity = 3,
                 status = RoomStatus.WAITING,
                 createdAt = null,
-                updatedAt = null,
+                updatedAt = null
             )
         ).toModel().id
 
@@ -67,7 +67,7 @@ class RoomServiceTest : IntegrationTest() {
                 password = "12345",
                 nickname = "testNickname",
                 createdAt = null,
-                updatedAt = null,
+                updatedAt = null
             )
         ).toModel().id
 

--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -36,11 +36,13 @@ class RoomConcurrencyTest {
     @BeforeTest
     fun clearBefore() {
         roomJpaRepository.deleteAll()
+        memberJpaRepository.deleteAll()
     }
 
     @AfterTest
     fun clearAfter() {
         roomJpaRepository.deleteAll()
+        memberJpaRepository.deleteAll()
     }
 
     @Test

--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -54,7 +54,7 @@ class RoomConcurrencyTest {
                 currCapacity = 0,
                 status = RoomStatus.WAITING,
                 createdAt = null,
-                updatedAt = null,
+                updatedAt = null
             )
         ).toModel().id
 
@@ -64,7 +64,7 @@ class RoomConcurrencyTest {
                 password = "12345",
                 nickname = "testNickname",
                 createdAt = null,
-                updatedAt = null,
+                updatedAt = null
             )
         ).toModel().id
 
@@ -72,7 +72,6 @@ class RoomConcurrencyTest {
         val startLatch = CountDownLatch(1)
         val doneLatch = CountDownLatch(numberOfThreads)
         val executor = Executors.newFixedThreadPool(numberOfThreads)
-
 
         // when
         for (idx in 1..numberOfThreads) {
@@ -99,4 +98,3 @@ class RoomConcurrencyTest {
         assertEquals(50, room.currCapacity) // 최대 5명만 수용 가능해야함
     }
 }
-

--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -1,0 +1,100 @@
+package yjh.cstar.room.concurrency
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import yjh.cstar.member.infrastructure.jpa.MemberEntity
+import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
+import yjh.cstar.room.domain.RoomStatus
+import yjh.cstar.room.infrastructure.jpa.RoomEntity
+import yjh.cstar.room.infrastructure.jpa.RoomJpaRepository
+import yjh.cstar.room.presentation.RoomController
+import yjh.cstar.room.presentation.request.RoomJoinRequest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@DisplayName("[동시성 테스트] RoomController")
+@ActiveProfiles("local-test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RoomConcurrencyTest {
+
+    @Autowired
+    private lateinit var roomController: RoomController
+
+    @Autowired
+    private lateinit var roomJpaRepository: RoomJpaRepository
+
+    @Autowired
+    private lateinit var memberJpaRepository: MemberJpaRepository
+
+    @BeforeTest
+    fun clearBefore() {
+        roomJpaRepository.deleteAll()
+    }
+
+    @AfterTest
+    fun clearAfter() {
+        roomJpaRepository.deleteAll()
+    }
+
+    @Test
+    fun `게임 방 참가 요청시 참가 인원 수 동시성 테스트`() {
+        // given
+        val roomId = roomJpaRepository.save(
+            RoomEntity(
+                maxCapacity = 100,
+                currCapacity = 0,
+                status = RoomStatus.WAITING,
+                createdAt = null,
+                updatedAt = null,
+            )
+        ).toModel().id
+
+        val memberId = memberJpaRepository.save(
+            MemberEntity(
+                email = "test@test.com",
+                password = "12345",
+                nickname = "testNickname",
+                createdAt = null,
+                updatedAt = null,
+            )
+        ).toModel().id
+
+        val numberOfThreads = 50
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(numberOfThreads)
+        val executor = Executors.newFixedThreadPool(numberOfThreads)
+
+
+        // when
+        for (idx in 1..numberOfThreads) {
+            executor.submit {
+                try {
+                    roomController.join(roomId, RoomJoinRequest(memberId))
+                } catch (e: Exception) {
+                    println("Error: ${e.message}")
+                } finally {
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown() // 모든 스레드 동시에 시작
+
+        doneLatch.await() // 모든 스레드 종료 대기
+
+        executor.shutdown()
+
+        // then
+        val room = roomJpaRepository.findByIdOrNull(roomId)?.toModel()
+        assertNotNull(room)
+        assertEquals(50, room.currCapacity) // 최대 5명만 수용 가능해야함
+    }
+}
+

--- a/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
@@ -2,6 +2,9 @@ package yjh.cstar.room.domain
 
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import yjh.cstar.common.BaseException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -22,5 +25,53 @@ class RoomTest {
         assertEquals(5, room.maxCapacity)
         assertEquals(0, room.currCapacity)
         assertEquals(RoomStatus.WAITING, room.status)
+    }
+
+    @Test
+    fun `게임 방 참가 성공 테스트`() {
+        // given
+        val room = Room(
+            maxCapacity = 5,
+            currCapacity = 3,
+            status = RoomStatus.WAITING,
+        )
+
+        // when
+        room.entrance()
+
+        // then
+        assertEquals(4, room.currCapacity)
+    }
+
+    @Test
+    fun `게임 방 참가 실패 테스트 - 인원 초과 `() {
+        // given
+        val room = Room(
+            maxCapacity = 5,
+            currCapacity = 5,
+            status = RoomStatus.WAITING,
+        )
+
+        // when & then
+        val exception = assertThrows<BaseException> {
+            room.entrance()
+        }
+        assertEquals(HttpStatus.CONFLICT, exception.baseErrorCode.httpStatus)
+    }
+
+    @Test
+    fun `게임 방 참가 실패 테스트 - 대기상태 아님 `() {
+        // given
+        val room = Room(
+            maxCapacity = 5,
+            currCapacity = 3,
+            status = RoomStatus.IN_PROGRESS,
+        )
+
+        // when & then
+        val exception = assertThrows<BaseException> {
+            room.entrance()
+        }
+        assertEquals(HttpStatus.CONFLICT, exception.baseErrorCode.httpStatus)
     }
 }

--- a/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
@@ -33,7 +33,7 @@ class RoomTest {
         val room = Room(
             maxCapacity = 5,
             currCapacity = 3,
-            status = RoomStatus.WAITING,
+            status = RoomStatus.WAITING
         )
 
         // when
@@ -49,7 +49,7 @@ class RoomTest {
         val room = Room(
             maxCapacity = 5,
             currCapacity = 5,
-            status = RoomStatus.WAITING,
+            status = RoomStatus.WAITING
         )
 
         // when & then
@@ -65,7 +65,7 @@ class RoomTest {
         val room = Room(
             maxCapacity = 5,
             currCapacity = 3,
-            status = RoomStatus.IN_PROGRESS,
+            status = RoomStatus.IN_PROGRESS
         )
 
         // when & then


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #27 

## 📝 작업한 내용
- [x] 게임 방 참가 기능 API 구현 및 도메인, 애플리케이션 테스트 진행
- [x] 게임 방 참가 요청시 참가 인원 수 동시성 테스트 진행
  -  게임 방 참가 요청시 동시성 문제 발생하여, (아직 까지는 단일 서버라) 간단하게 synchronized를 사용해 동시성 제어를 진행 했습니다.

## 💬 논의하고 싶은 내용
- 동시성 제어 관련해서 CountDownLatch 사용법 등을 같이 스터디해봐요😋😋😋