### PR TITLE
fix: 로그인 시 존재하지 않는 사용자에 대한 에러 코드 수정

### DIFF
--- a/src/main/kotlin/yjh/cstar/auth/application/UserDetailService.kt
+++ b/src/main/kotlin/yjh/cstar/auth/application/UserDetailService.kt
@@ -16,7 +16,7 @@ class UserDetailService(
 
     override fun loadUserByUsername(email: String): UserDetails {
         val member =
-            memberJpaRepository.findByEmail(email)?.toModel() ?: throw BaseException(BaseErrorCode.NOT_FOUND_ROOM)
+            memberJpaRepository.findByEmail(email)?.toModel() ?: throw BaseException(BaseErrorCode.NOT_FOUND_MEMBER)
         return createUser(email, member)
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #44

## 📝 작업한 내용
- [x] 로그인 시 존재하지 않는 사용자에 대한 에러 코드를 NOT_FOUND_ROOM에서 NOT_FOUND_MEMBER로 수정했습니다.

## 💬 논의하고 싶은 내용
- x
