### PR TITLE
fix: 하드코딩된 playerId를 Authentication에서 가져오도록 수정

### DIFF
--- a/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
+++ b/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
@@ -3,7 +3,9 @@ package yjh.cstar.websocket.presentation
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Controller
+import yjh.cstar.auth.jwt.TokenProvider
 import yjh.cstar.common.BaseErrorCode
 import yjh.cstar.common.BaseException
 import yjh.cstar.game.application.GameAnswerQueueService
@@ -13,13 +15,17 @@ import yjh.cstar.websocket.presentation.request.AnswerMessageRequest
 @Controller
 class StompController(
     private val gameAnswerQueueService: GameAnswerQueueService,
+    private val tokenProvider: TokenProvider,
 ) {
 
     @MessageMapping("/chatting/{roomId}")
     @SendTo("/topic/rooms/{roomId}")
-    fun chatting(@DestinationVariable roomId: Long, answerMessageReuqest: AnswerMessageRequest) {
-        // Authentication 에서 받아야함
-        val playerId = 1L
+    fun chatting(
+        @DestinationVariable roomId: Long,
+        answerMessageReuqest: AnswerMessageRequest,
+        authentication: Authentication,
+    ) {
+        val playerId = tokenProvider.getMemberId(authentication)
 
         require(answerMessageReuqest.answer.isBlank()) { BaseException(BaseErrorCode.EMPTY_ANSWER) }
         require(answerMessageReuqest.quizId <= 0) { BaseException(BaseErrorCode.INVALID_QUIZ_ID) }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #46

## 📝 작업한 내용
- [x] 사용자가 채팅 메시지를 보낼 때, 하드코딩된 playerId를 제거하고 Authentication에서 id를 가져와서 처리했습니다.

## 💬 논의하고 싶은 내용
- x