### PR TITLE
fix: 메세지응답양식추가 및 메세지전송시헤더검증

### DIFF
--- a/src/main/kotlin/yjh/cstar/game/application/GameEngineService.kt
+++ b/src/main/kotlin/yjh/cstar/game/application/GameEngineService.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import yjh.cstar.game.domain.AnswerResult
+import yjh.cstar.game.presentation.response.QuizInfoResponse
 import yjh.cstar.quiz.domain.Quiz
 import java.time.LocalDateTime
 import java.util.TreeMap
@@ -28,6 +29,7 @@ class GameEngineService(
         logger.info { "[INFO] 게임 엔진 스레드 시작 - roomId : $roomId" }
         val destination = "/topic/rooms/$roomId"
         val gameStartedAt = LocalDateTime.now()
+        broadCastService.sendMessage(destination, "start", "게임 시작 합니다. $roomId", null)
 
         broadCastService.sendMessage(destination, "guide", "GAME START!", null)
         broadCastService.sendMessage(destination, "guide", "각 문제당 ${TIME_LIMIT_MILLIS / 1000}초의 제한시간이 주어집니다.", null)
@@ -35,7 +37,12 @@ class GameEngineService(
         for ((idx, quiz) in quizzes.withIndex()) {
             val quizNo = idx + 1
 
-            broadCastService.sendMessage(destination, "quiz", "${quizNo}번 문제 입니다.", quiz.question)
+            broadCastService.sendMessage(
+                destination,
+                "quiz",
+                "${quizNo}번 문제 입니다.",
+                QuizInfoResponse(quiz.id, quiz.question)
+            )
 
             val startTime = System.currentTimeMillis()
             var notExistWinner = true

--- a/src/main/kotlin/yjh/cstar/game/presentation/response/QuizInfoResponse.kt
+++ b/src/main/kotlin/yjh/cstar/game/presentation/response/QuizInfoResponse.kt
@@ -1,0 +1,6 @@
+package yjh.cstar.game.presentation.response
+
+data class QuizInfoResponse(
+    val quizId: Long,
+    val quizQuestion: String,
+)

--- a/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
+++ b/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
@@ -1,10 +1,11 @@
 package yjh.cstar.websocket.presentation
 
 import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.SendTo
-import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Controller
+import org.springframework.util.StringUtils
 import yjh.cstar.auth.jwt.TokenProvider
 import yjh.cstar.common.BaseErrorCode
 import yjh.cstar.common.BaseException
@@ -22,22 +23,33 @@ class StompController(
     @SendTo("/topic/rooms/{roomId}")
     fun chatting(
         @DestinationVariable roomId: Long,
-        answerMessageReuqest: AnswerMessageRequest,
-        authentication: Authentication,
+        @Header("Authorization") bearerToken: String,
+        answerMessageRequest: AnswerMessageRequest,
     ) {
-        val playerId = tokenProvider.getMemberId(authentication)
+        val jwt = resolveToken(bearerToken)
+        val playerId = jwt
+            ?.takeIf { StringUtils.hasText(it) && tokenProvider.validateToken(it) }
+            ?.let { tokenProvider.getMemberId(tokenProvider.getAuthentication(it)) }
 
-        require(answerMessageReuqest.answer.isBlank()) { BaseException(BaseErrorCode.EMPTY_ANSWER) }
-        require(answerMessageReuqest.quizId <= 0) { BaseException(BaseErrorCode.INVALID_QUIZ_ID) }
+        requireNotNull(playerId) { BaseException(BaseErrorCode.UNAUTHORIZED) }
+        require(answerMessageRequest.answer.isNotBlank()) { BaseException(BaseErrorCode.EMPTY_ANSWER) }
+        require(answerMessageRequest.quizId > 0) { BaseException(BaseErrorCode.INVALID_QUIZ_ID) }
 
         val answer = AnswerResult(
-            answer = answerMessageReuqest.answer,
-            quizId = answerMessageReuqest.quizId,
+            answer = answerMessageRequest.answer,
+            quizId = answerMessageRequest.quizId,
             roomId = roomId,
             playerId = playerId
         )
 
         // 비동기 함수임
         gameAnswerQueueService.add(answer)
+    }
+
+    private fun resolveToken(bearerToken: String): String? {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7)
+        }
+        return null
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #54

## 📝 작업한 내용
- [x] 메세지 응답 양식 추가(퀴즈 시작을 알리는 메세지 타입)
- [x] 메세지를 컨트롤러에서 받을 때 헤더값을 검증하도록 변경 

## 💬 논의하고 싶은 내용
- 
