### PR TITLE
feat: 웹소켓 연결 종료시 게임방 인원 감소 기능 구현

### DIFF
--- a/src/main/kotlin/yjh/cstar/auth/jwt/TokenProvider.kt
+++ b/src/main/kotlin/yjh/cstar/auth/jwt/TokenProvider.kt
@@ -96,8 +96,12 @@ class TokenProvider(
 
     fun getMemberId(authentication: Authentication): Long {
         val jwtToken = getJwtTokenFrom(authentication)
+        return getMemberId(jwtToken)
+    }
+
+    fun getMemberId(token: String): Long {
         val claims = Jwts.parserBuilder().setSigningKey(key)
-            .build().parseClaimsJws(jwtToken)
+            .build().parseClaimsJws(token)
         return claims.body["memberId"].toString().toLong()
     }
 

--- a/src/main/kotlin/yjh/cstar/common/BaseErrorCode.kt
+++ b/src/main/kotlin/yjh/cstar/common/BaseErrorCode.kt
@@ -59,8 +59,9 @@ enum class BaseErrorCode(
     // 409
     NOT_IN_WAITING_STATUS(HttpStatus.CONFLICT, 4090, "게임 방이 현재 대기 상태가 아닙니다."),
     CAPACITY_EXCEEDED(HttpStatus.CONFLICT, 4091, "게임 방의 수용 가능 인원이 초과되었습니다."),
+    CAPACITY_CANNOT_BE_NEGATIVE(HttpStatus.CONFLICT, 4092, "게임 방 수용 인원은 음수가 될 수 없습니다."),
     CONFLICT_MEMBER(HttpStatus.CONFLICT, 40910, "회원이 이미 존재합니다."),
 
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 에러"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 에러"), ;
 }

--- a/src/main/kotlin/yjh/cstar/room/application/RoomService.kt
+++ b/src/main/kotlin/yjh/cstar/room/application/RoomService.kt
@@ -54,6 +54,13 @@ class RoomService(
     }
 
     @Transactional
+    fun leave(roomId: Long) {
+        val room = retrieve(roomId)
+        room.leave()
+        roomRepository.save(room)
+    }
+
+    @Transactional
     fun startGame(roomId: Long) {
         val room = retrieve(roomId)
         room.startGame()

--- a/src/main/kotlin/yjh/cstar/room/domain/Room.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/Room.kt
@@ -28,7 +28,7 @@ class Room(
     }
 
     fun leave() {
-        require(currCapacity != 0) { BaseException(BaseErrorCode.CAPACITY_CANNOT_BE_NEGATIVE) }
+        require(0 < currCapacity) { BaseException(BaseErrorCode.CAPACITY_CANNOT_BE_NEGATIVE) }
         currCapacity--
     }
 

--- a/src/main/kotlin/yjh/cstar/room/domain/Room.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/Room.kt
@@ -28,7 +28,7 @@ class Room(
     }
 
     fun leave() {
-        require(0 < currCapacity) { BaseException(BaseErrorCode.CAPACITY_CANNOT_BE_NEGATIVE) }
+        require(0 < currCapacity) { throw BaseException(BaseErrorCode.CAPACITY_CANNOT_BE_NEGATIVE) }
         currCapacity--
     }
 

--- a/src/main/kotlin/yjh/cstar/room/domain/Room.kt
+++ b/src/main/kotlin/yjh/cstar/room/domain/Room.kt
@@ -27,6 +27,11 @@ class Room(
         currCapacity++
     }
 
+    fun leave() {
+        require(currCapacity != 0) { BaseException(BaseErrorCode.CAPACITY_CANNOT_BE_NEGATIVE) }
+        currCapacity--
+    }
+
     fun startGame() {
         checkWaitingStatus()
         status = RoomStatus.IN_PROGRESS

--- a/src/main/kotlin/yjh/cstar/websocket/presentation/StompWebSocketEventHandler.kt
+++ b/src/main/kotlin/yjh/cstar/websocket/presentation/StompWebSocketEventHandler.kt
@@ -2,7 +2,9 @@ package yjh.cstar.websocket.presentation
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.event.EventListener
+import org.springframework.messaging.MessageHeaders
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.GenericMessage
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.messaging.AbstractSubProtocolEvent
 import org.springframework.web.socket.messaging.SessionConnectEvent
@@ -10,11 +12,20 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
 import org.springframework.web.socket.messaging.SessionSubscribeEvent
 import org.springframework.web.socket.messaging.SessionUnsubscribeEvent
+import yjh.cstar.auth.jwt.TokenProvider
+import yjh.cstar.room.application.RoomService
 
 private val logger = KotlinLogging.logger {}
 
 @Component
-class StompWebSocketEventHandler {
+class StompWebSocketEventHandler(
+    private val roomService: RoomService,
+    private val tokenProvider: TokenProvider,
+) {
+
+    companion object {
+        val sessions = mutableMapOf<String, Long>() // 세션 ID : 방 ID
+    }
 
     @EventListener
     fun handleWebSocketSessionConnectEventListener(event: SessionConnectEvent) {
@@ -24,6 +35,11 @@ class StompWebSocketEventHandler {
     @EventListener
     fun handleWebSocketSessionConnectedEventListener(event: SessionConnectedEvent) {
         logger.info { "연결 완료. 세션 ID: ${getSessionId(event)}" }
+
+        val session = getSessionId(event)
+        val roomId = getRoomId(event)
+
+        session?.let { sessions.put(it, roomId) }
     }
 
     @EventListener
@@ -39,6 +55,42 @@ class StompWebSocketEventHandler {
     @EventListener
     fun handleWebSocketSessionDisconnectEventListener(event: SessionDisconnectEvent) {
         logger.info { "연결 종료" }
+
+        val session = getSessionId(event)
+
+        session?.let {
+            val roomId = sessions.getOrDefault(it, -1)
+            sessions.remove(it)
+            roomService.leave(roomId)
+            logger.info { "roomService.leave() 호출" }
+        }
+    }
+
+    private fun getMemberId(event: AbstractSubProtocolEvent): Long {
+        val headers = getNativeHeader(event)
+
+        val authHeader = headers["Authorization"].toString()
+        val token = headers["Authorization"].toString().substring(8, authHeader.length - 1)
+        return tokenProvider.getMemberId(token)
+    }
+
+    private fun getRoomId(event: AbstractSubProtocolEvent): Long {
+        val headers = getNativeHeader(event)
+
+        val rawRoomId = headers["RoomId"].toString()
+        return headers["RoomId"].toString().substring(1, rawRoomId.length - 1).toLong()
+    }
+
+    private fun getNativeHeader(event: AbstractSubProtocolEvent): Map<*, *> {
+        val messageHeaders: MessageHeaders = getHeader(event).messageHeaders
+
+        val genericMessage = messageHeaders.values
+            .filter { it is GenericMessage<*> }
+            .first() as GenericMessage<*>
+
+        return genericMessage.headers.values
+            .filter { it is Map<*, *> && it::class.simpleName == "UnmodifiableMap" }
+            .first() as Map<*, *>
     }
 
     private fun getHeader(event: AbstractSubProtocolEvent) = StompHeaderAccessor.wrap(event.message)

--- a/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/domain/RoomTest.kt
@@ -13,6 +13,44 @@ import kotlin.test.assertNotNull
 class RoomTest {
 
     @Test
+    fun `게임 방 인원 수 감소 실패 테스트 - 0보다 같거나 작을 경우`() {
+        // given
+        val invalidCurrCapacity = listOf(-999, -1, 0)
+
+        invalidCurrCapacity.forEach { invalidCurrCapacity ->
+            val room = Room(
+                maxCapacity = 5,
+                currCapacity = invalidCurrCapacity,
+                status = RoomStatus.WAITING
+            )
+
+            // when
+            val exception = assertThrows<BaseException> {
+                room.leave()
+            }
+
+            // then
+            assertEquals(HttpStatus.CONFLICT, exception.baseErrorCode.httpStatus)
+        }
+    }
+
+    @Test
+    fun `게임 방 인원 수 감소 테스트`() {
+        // given
+        val room = Room(
+            maxCapacity = 5,
+            currCapacity = 3,
+            status = RoomStatus.WAITING
+        )
+
+        // when
+        room.leave()
+
+        // then
+        assertEquals(2, room.currCapacity)
+    }
+
+    @Test
     fun `게임 방 생성 테스트`() {
         // given
         val roomCreateCommand = RoomCreateCommand(maxCapacity = 5)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #39

## 📝 작업한 내용
- [x] 웹소켓 이벤트 핸들러에서 연결 종료시 게임방 인원 감소 기능 구현
- [x] 웹소켓 이벤트 핸들러에서 연결할 때 session id를 map 형태로 보관하는 기능 추가

## 💬 논의하고 싶은 내용
- 현재 방 인원수를 증가하고 감소하는 로직이 있기 때문에 동시성 문제를 고려해서 테이블에 락을 걸던가, 혹은 공통적으로 쓸 수 있는 Lock인스턴스를 생성하여 증가/감소 로직에 synchronized를 적용하도록 개선해야 될 것 같습니다.
