### PR TITLE
refactor : 퀴즈게임 진행중 실시간 랭킹 정보를 전송하도록 개선

### DIFF
--- a/src/main/kotlin/yjh/cstar/game/domain/AnswerResult.kt
+++ b/src/main/kotlin/yjh/cstar/game/domain/AnswerResult.kt
@@ -5,4 +5,5 @@ class AnswerResult(
     val quizId: Long,
     val roomId: Long,
     val playerId: Long,
+    val nickname: String,
 )

--- a/src/main/kotlin/yjh/cstar/game/infrastructure/redis/AnswerResultEntity.kt
+++ b/src/main/kotlin/yjh/cstar/game/infrastructure/redis/AnswerResultEntity.kt
@@ -7,6 +7,7 @@ class AnswerResultEntity(
     val quizId: Long,
     val roomId: Long,
     val playerId: Long,
+    val nickname: String,
 ) {
 
     companion object {
@@ -15,7 +16,8 @@ class AnswerResultEntity(
                 answer = answerResult.answer,
                 quizId = answerResult.quizId,
                 roomId = answerResult.roomId,
-                playerId = answerResult.playerId
+                playerId = answerResult.playerId,
+                nickname = answerResult.nickname
             )
         }
     }
@@ -25,7 +27,8 @@ class AnswerResultEntity(
             answer = this.answer,
             quizId = this.quizId,
             roomId = this.roomId,
-            playerId = this.playerId
+            playerId = this.playerId,
+            nickname = this.nickname
         )
     }
 }

--- a/src/main/kotlin/yjh/cstar/game/presentation/response/RankingResponse.kt
+++ b/src/main/kotlin/yjh/cstar/game/presentation/response/RankingResponse.kt
@@ -1,0 +1,5 @@
+package yjh.cstar.game.presentation.response
+
+data class RankingResponse(
+    val ranking: String,
+)

--- a/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
+++ b/src/main/kotlin/yjh/cstar/websocket/presentation/StompController.kt
@@ -39,7 +39,8 @@ class StompController(
             answer = answerMessageRequest.answer,
             quizId = answerMessageRequest.quizId,
             roomId = roomId,
-            playerId = playerId
+            playerId = playerId,
+            nickname = answerMessageRequest.nickname
         )
 
         // 비동기 함수임

--- a/src/main/kotlin/yjh/cstar/websocket/presentation/request/AnswerMessageRequest.kt
+++ b/src/main/kotlin/yjh/cstar/websocket/presentation/request/AnswerMessageRequest.kt
@@ -3,4 +3,5 @@ package yjh.cstar.websocket.presentation.request
 data class AnswerMessageRequest(
     val answer: String,
     val quizId: Long,
+    val nickname: String,
 )

--- a/src/test/kotlin/yjh/cstar/game/application/GameAnswerQueueServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/game/application/GameAnswerQueueServiceTest.kt
@@ -85,7 +85,8 @@ class GameAnswerQueueServiceTest {
             answer = "answer",
             roomId = ROOM_ID,
             quizId = QUIZ_ID,
-            playerId = 1
+            playerId = 1,
+            nickname = "nickname"
         )
 
         // when
@@ -103,7 +104,8 @@ class GameAnswerQueueServiceTest {
             answer = "answer",
             roomId = ROOM_ID,
             quizId = QUIZ_ID,
-            playerId = 1
+            playerId = 1,
+            nickname = "nickname"
         )
         val value = objectMapper.writeValueAsString(answerResultEntity)
         redisTemplate.opsForList().rightPush(KEY, value)

--- a/src/test/kotlin/yjh/cstar/redis/RedisTest.kt
+++ b/src/test/kotlin/yjh/cstar/redis/RedisTest.kt
@@ -77,9 +77,9 @@ class RedisTest {
     @Test
     fun `레디스 큐에 데이터 삽입 테스트`() {
         // given
-        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1))
+        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_1)
-        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1))
+        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_2)
 
         // when
@@ -93,9 +93,9 @@ class RedisTest {
     @Test
     fun `레디스 큐에 데이터 반환 테스트`() {
         // given
-        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1))
+        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_1)
-        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1))
+        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_2)
 
         // when
@@ -114,9 +114,9 @@ class RedisTest {
     @Test
     fun `레디스 큐의 특정 key에 해당하는 큐 삭제 테스트`() {
         // given
-        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1))
+        val value_1 = objectMapper.writeValueAsString(AnswerResultEntity("ans_1", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_1)
-        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1))
+        val value_2 = objectMapper.writeValueAsString(AnswerResultEntity("ans_2", QUIZ_ID, ROOM_ID, 1, "nickname"))
         redisQueueRepository.add(KEY, value_2)
 
         // when


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #66

## 📝 작업한 내용
- [x] 퀴즈게임 진행중 실시간 랭킹 정보를 전송하도록 개선
  - [x] 플레이어 닉네임 정보도 같이 전송하도록 개선
  - [x] nicknames 라는 Map을 통해 플레이어 id와 닉네임 정보를 기억
  - [x] ranking과 nicknames는 게임마다 유효한 데이터 이므로, `@Async` 메서드 내부로 위치를 옮겼다.(전역 변수 영역에 선언하면 안됨)

## 💬 논의하고 싶은 내용
- x
