### PR TITLE
refactor: GameEngineService의 책임을 분리하여 구조 개선

### DIFF
--- a/src/main/kotlin/yjh/cstar/engine/application/AnswerValidationService.kt
+++ b/src/main/kotlin/yjh/cstar/engine/application/AnswerValidationService.kt
@@ -1,0 +1,11 @@
+package yjh.cstar.engine.application
+
+import org.springframework.stereotype.Service
+
+@Service
+class AnswerValidationService {
+    fun validateAnswer(submittedAnswer: String, correctAnswer: String): Boolean {
+        return submittedAnswer.replace(" ", "")
+            .equals(correctAnswer.replace(" ", ""), ignoreCase = true)
+    }
+}

--- a/src/main/kotlin/yjh/cstar/engine/application/RankingService.kt
+++ b/src/main/kotlin/yjh/cstar/engine/application/RankingService.kt
@@ -1,0 +1,22 @@
+package yjh.cstar.engine.application
+
+import org.springframework.stereotype.Service
+import java.util.TreeMap
+
+@Service
+class RankingService() {
+    fun generateRanking(ranking: TreeMap<Long, Int>, nicknames: Map<Long, String>): String {
+        val sortedRankingDescending = ranking.entries.sortedByDescending { it.value }
+        val result = StringBuilder()
+        for ((index, entry) in sortedRankingDescending.withIndex()) {
+            val playerNickname = nicknames[entry.key]
+            val score = entry.value
+            result.append("[${index + 1}등 $playerNickname-$score]  ")
+        }
+        return result.toString()
+    }
+
+    fun calculateGameResult(ranking: TreeMap<Long, Int>): Long {
+        return ranking.maxByOrNull { it.value }?.key ?: -1
+    }
+}

--- a/src/main/kotlin/yjh/cstar/engine/application/RankingService.kt
+++ b/src/main/kotlin/yjh/cstar/engine/application/RankingService.kt
@@ -1,22 +1,24 @@
 package yjh.cstar.engine.application
 
 import org.springframework.stereotype.Service
-import java.util.TreeMap
+import yjh.cstar.engine.domain.Ranking
 
 @Service
 class RankingService() {
-    fun generateRanking(ranking: TreeMap<Long, Int>, nicknames: Map<Long, String>): String {
-        val sortedRankingDescending = ranking.entries.sortedByDescending { it.value }
+    fun getRankingMessage(ranking: Ranking, nicknames: Map<Long, String>): String {
+        val sortedRankingDescending = ranking.sortByScore()
         val result = StringBuilder()
-        for ((index, entry) in sortedRankingDescending.withIndex()) {
-            val playerNickname = nicknames[entry.key]
-            val score = entry.value
+
+        val sortedList = sortedRankingDescending.entries.sortedByDescending { it.key }
+        for ((index, entry) in sortedList.withIndex()) {
+            val score = entry.key
+            val playerNickname = nicknames[entry.value.toLong()]
             result.append("[${index + 1}등 $playerNickname-$score]  ")
         }
         return result.toString()
     }
 
-    fun calculateGameResult(ranking: TreeMap<Long, Int>): Long {
-        return ranking.maxByOrNull { it.value }?.key ?: -1
+    fun getWinnerId(ranking: Ranking): Long {
+        return ranking.getWinnerId()
     }
 }

--- a/src/main/kotlin/yjh/cstar/engine/application/ScoreManagementService.kt
+++ b/src/main/kotlin/yjh/cstar/engine/application/ScoreManagementService.kt
@@ -1,0 +1,12 @@
+package yjh.cstar.engine.application
+
+import org.springframework.stereotype.Service
+import java.util.TreeMap
+
+@Service
+class ScoreManagementService {
+    fun updateScore(ranking: TreeMap<Long, Int>, playerId: Long) {
+        val score = ranking.getOrDefault(playerId, 0)
+        ranking[playerId] = score + 1
+    }
+}

--- a/src/main/kotlin/yjh/cstar/engine/domain/Ranking.kt
+++ b/src/main/kotlin/yjh/cstar/engine/domain/Ranking.kt
@@ -1,0 +1,38 @@
+package yjh.cstar.engine.domain
+
+import yjh.cstar.common.BaseErrorCode
+import yjh.cstar.common.BaseException
+import java.util.*
+
+class Ranking(
+    private val players: List<Long>,
+    val ranking: TreeMap<Long, Int> = TreeMap<Long, Int>().apply {
+        players.forEach { this[it] = 0 }
+    },
+) {
+
+    fun updateScore(playerId: Long) {
+        val score = ranking.getOrDefault(playerId, 0)
+        ranking[playerId] = score + 1
+    }
+
+    fun getWinnerId(): Long {
+        val (playerId, score) = ranking.maxByOrNull { it.value }
+            ?: throw BaseException(BaseErrorCode.INTERNAL_SERVER_ERROR)
+
+        return when {
+            score == 0 -> -1
+            else -> playerId
+        }
+    }
+
+    fun sortByScore(): TreeMap<Long, Int> {
+        val sortedEntries = ranking.entries.sortedByDescending { it.value }
+
+        val sortedMap = TreeMap<Long, Int>()
+        for (entry in sortedEntries) {
+            sortedMap[entry.value.toLong()] = entry.key.toInt()
+        }
+        return sortedMap
+    }
+}

--- a/src/main/kotlin/yjh/cstar/game/application/GameService.kt
+++ b/src/main/kotlin/yjh/cstar/game/application/GameService.kt
@@ -19,8 +19,9 @@ class GameService(
         roomService.startGame(command.roomId)
 
         val quizzes = quizService.getQuizzes(command.quizCategoryId, command.totalQuestions)
+        val players: List<Long> = roomService.retrieveCurrParticipant(command.roomId)
 
         // 실제 퀴즈 실행하는 비동기 메서드
-        gameEngineService.start(quizzes, command.roomId)
+        gameEngineService.start(players, quizzes, command.roomId)
     }
 }

--- a/src/main/kotlin/yjh/cstar/game/application/GameService.kt
+++ b/src/main/kotlin/yjh/cstar/game/application/GameService.kt
@@ -2,6 +2,7 @@ package yjh.cstar.game.application
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import yjh.cstar.engine.application.GameEngineService
 import yjh.cstar.game.domain.GameStartCommand
 import yjh.cstar.quiz.application.QuizService
 import yjh.cstar.room.application.RoomService

--- a/src/main/kotlin/yjh/cstar/game/presentation/request/RankingCreateRequest.kt
+++ b/src/main/kotlin/yjh/cstar/game/presentation/request/RankingCreateRequest.kt
@@ -1,0 +1,13 @@
+package yjh.cstar.game.presentation.request
+
+import java.time.LocalDateTime
+import java.util.*
+
+data class RankingCreateRequest(
+    val sortedRanking: TreeMap<Long, Int>,
+    val roomId: Long,
+    val winningPlayerId: Long,
+    val totalQuizSize: Int,
+    val categoryId: Long,
+    val gameStartedAt: LocalDateTime,
+)

--- a/src/test/kotlin/yjh/cstar/engine/application/AnswerValidationServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/engine/application/AnswerValidationServiceTest.kt
@@ -1,0 +1,53 @@
+package yjh.cstar.engine.application
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import yjh.cstar.IntegrationTest
+import kotlin.test.assertTrue
+
+@DisplayName("[Application 테스트] AnswerValidationService")
+class AnswerValidationServiceTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var answerValidationService: AnswerValidationService
+
+    @Test
+    fun `플레이어 정답 확인 테스트`() {
+        // given
+        val submittedAnswer = "정답"
+        val correctAnswer = "정답"
+
+        // when
+        val result = answerValidationService.validateAnswer(submittedAnswer, correctAnswer)
+
+        // then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `플레이어 정답 확인 테스트 - 띄어쓰기에 관계없이 정답 처리`() {
+        // given
+        val submittedAnswer = "정 답"
+        val correctAnswer = " 정답 "
+
+        // when
+        val result = answerValidationService.validateAnswer(submittedAnswer, correctAnswer)
+
+        // then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `플레이어 정답 확인 테스트 - 대소문자에 관계없이 정답 처리`() {
+        // given
+        val submittedAnswer = "answer"
+        val correctAnswer = "ANSWER"
+
+        // when
+        val result = answerValidationService.validateAnswer(submittedAnswer, correctAnswer)
+
+        // then
+        assertTrue(result)
+    }
+}

--- a/src/test/kotlin/yjh/cstar/engine/application/RankingServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/engine/application/RankingServiceTest.kt
@@ -1,0 +1,67 @@
+package yjh.cstar.engine.application
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import yjh.cstar.IntegrationTest
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@DisplayName("[Application 테스트] RankingService")
+class RankingServiceTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var rankingService: RankingService
+
+    @Test
+    fun `퀴즈별 플레이어 랭킹 계산 테스트`() {
+        // given
+        val ranking = TreeMap<Long, Int>()
+        val nicknames = mutableMapOf<Long, String>()
+
+        ranking[1L] = 2
+        ranking[2L] = 3
+        ranking[3L] = 1
+
+        nicknames[1L] = "플레이어1"
+        nicknames[2L] = "플레이어2"
+        nicknames[3L] = "플레이어3"
+
+        // when
+        val rankingMessage = rankingService.generateRanking(ranking, nicknames)
+
+        // then
+        val expected = "[1등 플레이어2-3]  [2등 플레이어1-2]  [3등 플레이어3-1]  "
+        assertEquals(expected, rankingMessage)
+    }
+
+    @Test
+    fun `최종 게임 결과 계산 테스트 - 최종 1등인 플레이어 아이디를 반환한다`() {
+        // given
+        val ranking = TreeMap<Long, Int>()
+
+        ranking[1L] = 2
+        ranking[2L] = 3
+        ranking[3L] = 1
+
+        // when
+        val winningPlayerId = rankingService.calculateGameResult(ranking)
+
+        // then
+        assertNotNull(winningPlayerId)
+        assertEquals(winningPlayerId, 2L)
+    }
+
+    @Test
+    fun `최종 게임 결과 계산 테스트 - 아무도 퀴즈를 풀지 못했을 경우 -1을 반환한다 `() {
+        // given
+        val ranking = TreeMap<Long, Int>()
+
+        // when
+        val winningPlayerId = rankingService.calculateGameResult(ranking)
+
+        // then
+        assertEquals(winningPlayerId, -1)
+    }
+}

--- a/src/test/kotlin/yjh/cstar/engine/application/RankingServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/engine/application/RankingServiceTest.kt
@@ -2,9 +2,12 @@ package yjh.cstar.engine.application
 
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import yjh.cstar.IntegrationTest
-import java.util.*
+import yjh.cstar.common.BaseException
+import yjh.cstar.engine.domain.Ranking
+import java.util.TreeMap
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -17,19 +20,21 @@ class RankingServiceTest : IntegrationTest() {
     @Test
     fun `퀴즈별 플레이어 랭킹 계산 테스트`() {
         // given
-        val ranking = TreeMap<Long, Int>()
-        val nicknames = mutableMapOf<Long, String>()
-
-        ranking[1L] = 2
-        ranking[2L] = 3
-        ranking[3L] = 1
-
-        nicknames[1L] = "플레이어1"
-        nicknames[2L] = "플레이어2"
-        nicknames[3L] = "플레이어3"
+        val players = listOf(1L, 2L, 3L)
+        val playerScores = TreeMap<Long, Int>().apply {
+            put(1L, 2)
+            put(2L, 3)
+            put(3L, 1)
+        }
+        val nicknames = mutableMapOf<Long, String>().apply {
+            put(1L, "플레이어1")
+            put(2L, "플레이어2")
+            put(3L, "플레이어3")
+        }
+        val ranking = Ranking(players, playerScores)
 
         // when
-        val rankingMessage = rankingService.generateRanking(ranking, nicknames)
+        val rankingMessage = rankingService.getRankingMessage(ranking, nicknames)
 
         // then
         val expected = "[1등 플레이어2-3]  [2등 플레이어1-2]  [3등 플레이어3-1]  "
@@ -39,14 +44,16 @@ class RankingServiceTest : IntegrationTest() {
     @Test
     fun `최종 게임 결과 계산 테스트 - 최종 1등인 플레이어 아이디를 반환한다`() {
         // given
-        val ranking = TreeMap<Long, Int>()
-
-        ranking[1L] = 2
-        ranking[2L] = 3
-        ranking[3L] = 1
+        val players = listOf(1L, 2L, 3L)
+        val playerScores = TreeMap<Long, Int>().apply {
+            put(1L, 2)
+            put(2L, 3)
+            put(3L, 1)
+        }
+        val ranking = Ranking(players, playerScores)
 
         // when
-        val winningPlayerId = rankingService.calculateGameResult(ranking)
+        val winningPlayerId = ranking.getWinnerId()
 
         // then
         assertNotNull(winningPlayerId)
@@ -54,14 +61,25 @@ class RankingServiceTest : IntegrationTest() {
     }
 
     @Test
-    fun `최종 게임 결과 계산 테스트 - 아무도 퀴즈를 풀지 못했을 경우 -1을 반환한다 `() {
+    fun `최종 게임 결과 계산 테스트 - 아무도 퀴즈를 풀지 못했을 경우 -1을 반환한다`() {
         // given
-        val ranking = TreeMap<Long, Int>()
+        val players = listOf(1L, 2L, 3L)
+        val ranking = Ranking(players)
 
         // when
-        val winningPlayerId = rankingService.calculateGameResult(ranking)
+        val winningPlayerId = ranking.getWinnerId()
 
         // then
-        assertEquals(winningPlayerId, -1)
+        assertEquals(-1, winningPlayerId)
+    }
+
+    @Test
+    fun `최종 게임 결과 계산 테스트 - 플레이어가 존재하지 않을 경우 예외를 반환한다`() {
+        // given
+        val players = emptyList<Long>()
+        val ranking = Ranking(players)
+
+        // when & then
+        assertThrows<BaseException> { ranking.getWinnerId() }
     }
 }

--- a/src/test/kotlin/yjh/cstar/engine/application/ScoreManagementServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/engine/application/ScoreManagementServiceTest.kt
@@ -1,0 +1,29 @@
+package yjh.cstar.engine.application
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import yjh.cstar.IntegrationTest
+import java.util.*
+import kotlin.test.assertEquals
+
+@DisplayName("[Application 테스트] ScoreManagementService")
+class ScoreManagementServiceTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var scoreManagementService: ScoreManagementService
+
+    @Test
+    fun `점수 갱신 테스트 - 정답을 맞춘 플레이어의 점수를 1점 올린다`() {
+        // given
+        val ranking = TreeMap<Long, Int>()
+        ranking[1L] = 3
+        val playerId = 1L
+
+        // when
+        scoreManagementService.updateScore(ranking, playerId)
+
+        // then
+        assertEquals(4, ranking[playerId])
+    }
+}

--- a/src/test/kotlin/yjh/cstar/game/application/GameResultServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/game/application/GameResultServiceTest.kt
@@ -9,6 +9,7 @@ import yjh.cstar.common.BaseException
 import yjh.cstar.game.infrastructure.jpa.GameEntity
 import yjh.cstar.game.infrastructure.jpa.GameJpaRepository
 import yjh.cstar.game.infrastructure.jpa.GameResultJpaRepository
+import yjh.cstar.game.presentation.request.RankingCreateRequest
 import yjh.cstar.room.domain.RoomStatus
 import yjh.cstar.room.infrastructure.jpa.RoomEntity
 import yjh.cstar.room.infrastructure.jpa.RoomJpaRepository
@@ -45,20 +46,22 @@ class GameResultServiceTest : IntegrationTest() {
             )
         ).toModel().id
 
-        val ranking = TreeMap<Long, Int>()
-        ranking[2L] = 5
-        ranking[3L] = 3
-        ranking[1L] = 2
+        val playerScores = TreeMap<Long, Int>().apply {
+            put(2L, 5)
+            put(3L, 3)
+            put(1L, 2)
+        }
 
-        // when
-        gameResultService.create(
-            ranking = ranking,
-            gameStartedAt = LocalDateTime.now(),
-            roomId = roomId,
-            winningPlayerId = 2L,
-            totalQuizSize = 10,
-            categoryId = 1L
+        val rankingCreateRequest = RankingCreateRequest(
+            playerScores,
+            roomId,
+            2L,
+            10,
+            1L,
+            LocalDateTime.now()
         )
+        // when
+        gameResultService.create(rankingCreateRequest)
 
         // then
         // 1. Game
@@ -98,19 +101,21 @@ class GameResultServiceTest : IntegrationTest() {
             )
         ).toModel()
 
-        val ranking = TreeMap<Long, Int>().apply {
-            put(1L, 3)
-            put(2L, 2)
+        val playerScores = TreeMap<Long, Int>().apply {
+            put(2L, 5)
+            put(3L, 3)
+            put(1L, 2)
         }
 
-        gameResultService.create(
-            ranking = ranking,
-            gameStartedAt = LocalDateTime.now(),
-            roomId = savedRoom.id,
-            winningPlayerId = 1L,
-            totalQuizSize = 5,
-            categoryId = 1L
+        val rankingCreateRequest = RankingCreateRequest(
+            playerScores,
+            savedRoom.id,
+            1L,
+            5,
+            1L,
+            LocalDateTime.now()
         )
+        gameResultService.create(rankingCreateRequest)
 
         // then
         val updatedRoom = roomJpaRepository.findByIdOrNull(savedRoom.id)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #79

## 📝 작업한 내용
- [x] 기존 GameEngineService의 복잡한 로직을 책임별로 서비스로 분리한 후 통합 테스트를 진행했습니다.
  - [x] AnswerValidationService: 플레이어의 답변을 검증합니다.
  - [x] RankingService: 실시간 플레이어들의 랭킹을 산정하고, 최종 승리자를 계산합니다.
  - [x] ScoreManagementService: 플레이어의 점수를 관리합니다.

## 💬 논의하고 싶은 내용
- 1️⃣ Ranking.sortByScore()에서 점수(value)를 기준으로 내림차순 정렬된 List를 TreeMap으로 변환할 때 이슈가 있었습니다.
  - TreeMap은 키로 정렬되기 때문에 점수를 기준으로 내림차순 정렬된 순서를 유지하지 못합니다.
  - 그래서 해당 메서드에서 `밸류:키` 형태로 저장하고, RankingService의 getRankingMessage() 내에서 다시 점수로 내림차순 정렬을 적용하고 저장하는 번거로움이 있었습니다.
  - 이 시점에서 다른 기술을 학습하여 도입할 필요성을 느꼈습니다.😂😂

- 2️⃣ 전체적으로 매직 넘버가 존재하고, 현재 가독성이 좋지 않은 GameEngineService의 리팩토링은 별도의 이슈를 생성하여 작업하는 것이 좋을 것 같은데, 어떻게 생각하시나요?