### PR TITLE
fix: sql.init을 사용하지 않도록 제거

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,11 +24,6 @@ spring:
     password: local_password
     baseline-on-migrate: true
     locations: classpath:/db
-  sql:
-    init:
-      mode: always
-      data-locations:
-        - classpath:/data/init_insert_quiz_data.sql
   data:
     redis:
         host: localhost


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #90

## 📝 작업한 내용
- [x] sql.init을 사용하지 않도록 제거

## 💬 논의하고 싶은 내용
- 필요한 경우 data 에 있는 sql문을 직접 실행시켜서 넣는게 좋을 것 같습니다!!(각자 로컬 개발환경에서만)
