### PR TITLE
fix: jwt토큰 없어도 에러를 반환하지 않도록 수정

### DIFF
--- a/src/main/kotlin/yjh/cstar/auth/jwt/JwtFilter.kt
+++ b/src/main/kotlin/yjh/cstar/auth/jwt/JwtFilter.kt
@@ -7,8 +7,6 @@ import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.util.StringUtils
 import org.springframework.web.filter.GenericFilterBean
-import yjh.cstar.common.BaseErrorCode
-import yjh.cstar.common.BaseException
 import yjh.cstar.util.Logger
 
 class JwtFilter(
@@ -40,11 +38,11 @@ class JwtFilter(
         filterChain.doFilter(servletRequest, servletResponse)
     }
 
-    private fun resolveToken(request: HttpServletRequest): String {
+    private fun resolveToken(request: HttpServletRequest): String? {
         val bearerToken = request.getHeader(AUTHORIZATION_HEADER)
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_TYPE_BEARER)) {
             return bearerToken.substring(TOKEN_TYPE_BEARER.length)
         }
-        throw BaseException(BaseErrorCode.UNAUTHORIZED)
+        return null
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #111 

## 📝 작업한 내용
- [x] jwt토큰이 없더라도 에러가 아닌 return null로 로직 수정

## 💬 논의하고 싶은 내용
- 인증 테스트를 추가해야할 것 같습니다 😂😂
