### PR TITLE
refactor: 정답 판단 로직 개선

### DIFF
--- a/src/main/kotlin/yjh/cstar/play/domain/QuizGame.kt
+++ b/src/main/kotlin/yjh/cstar/play/domain/QuizGame.kt
@@ -54,6 +54,7 @@ class QuizGame(
                 gameNotifier.notifyQuizQuestion(destination, quizNo, quiz)
 
                 val roundStartTime = getCurrentTime()
+                // TODO("while true 를 사용하지 않도록 수정할 것")
                 while (true) {
                     Logger.info("[INFO] 정답 대기중...")
 

--- a/src/main/kotlin/yjh/cstar/play/domain/quiz/Quiz.kt
+++ b/src/main/kotlin/yjh/cstar/play/domain/quiz/Quiz.kt
@@ -10,5 +10,9 @@ class Quiz(
         fun of(id: Long, question: String, answer: String) = Quiz(id, question, answer)
     }
 
-    fun isSameAnswer(answer: String) = this.answer == answer
+    fun isSameAnswer(playerAnswer: String) = normalize(this.answer) == normalize(playerAnswer)
+
+    private fun normalize(str: String): String {
+        return str.replace("\\s".toRegex(), "").lowercase()
+    }
 }

--- a/src/test/kotlin/yjh/cstar/play/domain/quiz/QuizTest.kt
+++ b/src/test/kotlin/yjh/cstar/play/domain/quiz/QuizTest.kt
@@ -1,10 +1,12 @@
 package yjh.cstar.play.domain.quiz
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
 
 @DisplayName("[Domain 테스트] Quiz")
 class QuizTest {
@@ -20,28 +22,28 @@ class QuizTest {
         assertDoesNotThrow { Quiz.of(quizId, question, answer) }
     }
 
-    @Test
-    fun `같은 정답을 가지고 있는지 테스트`() {
+    @ParameterizedTest
+    @CsvSource(
+        "정답, 정 답,true",
+        "정   답, 정답, true",
+        "abc, ABC, true" // 공백이 포함된 경우 등 다양한 케이스도 추가 가능
+    )
+    fun `같은 정답을 가지고 있는지 테스트`(answer: String, playerAnswer: String, expected: Boolean) {
         // given
-        val quizId = 1L
-        val question = "질문"
-        val answer = "정답"
-        val quiz = Quiz(quizId, question, answer)
+        val quiz = Quiz(1L, "question", answer)
 
         // when
-        val isSameAnswer = quiz.isSameAnswer("정답")
+        val isSameAnswer = quiz.isSameAnswer(playerAnswer)
 
         // then
-        assertTrue(isSameAnswer)
+        assertEquals(expected, isSameAnswer)
     }
 
     @Test
     fun `다른 정답을 가지고 있는지 테스트`() {
         // given
-        val quizId = 1L
-        val question = "질문"
         val answer = "정답"
-        val quiz = Quiz(quizId, question, answer)
+        val quiz = Quiz(1L, "질문", answer)
 
         // when
         val isSameAnswer = quiz.isSameAnswer("잘못된 정답")


### PR DESCRIPTION


## #️⃣ 관련 이슈
- #123

## 📝 작업한 내용
- [x] 대소문자와 띄어쓰기를 구별하지 않고, 정답을 판별하도록 개선

## 💬 논의하고 싶은 내용
단답형 말고, 주관식 답도 판단해줄 수 있는 서비스도 추후에 고려해보면 좋을 것 같아요(AI를 곁들인..)