### PR TITLE
fix: roomJoinEntity jpa 연결 테스트 실패 문제 해결

### DIFF
--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import yjh.cstar.room.infrastructure.jpa.RoomJoinJpaRepository
 
 @DisplayName("[동시성 테스트] RoomConcurrency")
 @ActiveProfiles("local-test")
@@ -32,6 +33,9 @@ class RoomConcurrencyTest {
     private lateinit var roomJpaRepository: RoomJpaRepository
 
     @Autowired
+    private lateinit var roomJoinJpaRepository: RoomJoinJpaRepository
+
+    @Autowired
     private lateinit var memberJpaRepository: MemberJpaRepository
 
     @Autowired
@@ -40,12 +44,14 @@ class RoomConcurrencyTest {
     @BeforeTest
     fun clearBefore() {
         roomJpaRepository.deleteAll()
+        roomJoinJpaRepository.deleteAll()
         memberJpaRepository.deleteAll()
     }
 
     @AfterTest
     fun clearAfter() {
         roomJpaRepository.deleteAll()
+        roomJoinJpaRepository.deleteAll()
         memberJpaRepository.deleteAll()
     }
 

--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -10,6 +10,7 @@ import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
 import yjh.cstar.room.domain.RoomStatus
 import yjh.cstar.room.infrastructure.jpa.RoomEntity
+import yjh.cstar.room.infrastructure.jpa.RoomJoinJpaRepository
 import yjh.cstar.room.infrastructure.jpa.RoomJpaRepository
 import yjh.cstar.room.presentation.RoomController
 import yjh.cstar.util.Logger
@@ -19,7 +20,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import yjh.cstar.room.infrastructure.jpa.RoomJoinJpaRepository
 
 @DisplayName("[동시성 테스트] RoomConcurrency")
 @ActiveProfiles("local-test")


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #128 

## 📝 작업한 내용
- [x] room 동시성 테스트 AfterTest, BeforeTest 에 roomJoinEntity 데이터를 clear 하도록 수정해서 문제해결
<img width="301" alt="image" src="https://github.com/user-attachments/assets/007bddf8-70ac-4722-9636-dcf55592fcb2" />



## 💬 논의하고 싶은 내용
- x
