### PR TITLE
refactor: 싱글톤으로 테스트컨테이너를 관리하도록 변경

### DIFF
--- a/src/test/kotlin/yjh/cstar/IntegrationTest.kt
+++ b/src/test/kotlin/yjh/cstar/IntegrationTest.kt
@@ -2,9 +2,37 @@ package yjh.cstar
 
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import yjh.cstar.MySQLTestContainer.MYSQL_CONTAINER
+import yjh.cstar.RedisTestContainer.REDIS_CONTAINER
 
-@Transactional
-@ActiveProfiles("local-test")
+/**
+ * 통합 테스트를 사용할 때 다음 추상클래스를 상속해서 사용합니다.
+ * 테스트 시작시 프로젝트에 사용되는 infra 환경(ex mysql, redis)은 싱글톤 기반의 TestContainer 로 구동중입니다.
+ */
+@ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-abstract class IntegrationTest
+abstract class IntegrationTest {
+
+    /**
+     * SpringBoot .java 파일에서 kotlin companion object 에 접근하여 java 의 static 처럼 사용하기 위해 @JvmStatic 을 사용합니다.
+     * Application Context 로드시 동적으로 컨테이너 정보를 테스트용 application.yml 에 주입하기 위해 @DynamicPropertySource 를 사용합니다.
+     */
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun setDataSourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl)
+            registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername)
+            registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword)
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost)
+            registry.add("spring.data.redis.port", REDIS_CONTAINER::getFirstMappedPort)
+        }
+    }
+}

--- a/src/test/kotlin/yjh/cstar/MySQLTestContainer.kt
+++ b/src/test/kotlin/yjh/cstar/MySQLTestContainer.kt
@@ -1,0 +1,50 @@
+package yjh.cstar
+
+import org.testcontainers.containers.MySQLContainer
+
+/**
+ * 통합 테스트를 위한 MYSQL 싱글톤 컨테이너 입니다.
+ * 테스트 전역에서 싱글톤으로 접근해서 사용합니다.
+ * 최초 테스트 실행시 JVM static 영역에 로드됩니다.
+ */
+object MySQLTestContainer {
+    val MYSQL_CONTAINER = MySQLContainer("mysql:8.0.35").apply {
+        withDatabaseName("test-db")
+        withUsername("root")
+        withPassword("1234")
+        withUrlParam("serverTimeZone", "UTC")
+        withUrlParam("useSSL", "false")
+        withUrlParam("allowPublicKeyRetrieval", "true")
+    }
+
+    init {
+        MYSQL_CONTAINER.start()
+    }
+}
+
+// Example - Java 싱글톤 클래스
+//
+// public class MySQLTestContainer {
+//
+//     private static final MySQLContainer<?> MYSQL_CONTAINER;
+//
+//     static {
+//         MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0.35")
+//             .withDatabaseName("test-db")
+//             .withUsername("root")
+//             .withPassword("1234")
+//             .withUrlParam("serverTimeZone", "UTC")
+//             .withUrlParam("useSSL", "false")
+//             .withUrlParam("allowPublicKeyRetrieval", "true");
+//
+//         MYSQL_CONTAINER.start();
+//     }
+//
+//     private MySQLTestContainer() {
+//         // Private constructor to prevent instantiation
+//     }
+//
+//     public static MySQLContainer<?> getInstance() {
+//         return MYSQL_CONTAINER;
+//     }
+// }

--- a/src/test/kotlin/yjh/cstar/RedisTestContainer.kt
+++ b/src/test/kotlin/yjh/cstar/RedisTestContainer.kt
@@ -1,0 +1,18 @@
+package yjh.cstar
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * 통합 테스트를 위한 REDIS 싱글톤 컨테이너 입니다.
+ * 테스트 전역에서 싱글톤으로 접근해서 사용합니다.
+ * 최초 테스트 실행시 JVM static 영역에 로드됩니다.
+ */
+object RedisTestContainer {
+    val REDIS_CONTAINER: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:latest"))
+        .withExposedPorts(6379)
+
+    init {
+        REDIS_CONTAINER.start()
+    }
+}

--- a/src/test/kotlin/yjh/cstar/chat/ChatTest.kt
+++ b/src/test/kotlin/yjh/cstar/chat/ChatTest.kt
@@ -3,19 +3,16 @@ package yjh.cstar.chat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.messaging.converter.MappingJackson2MessageConverter
 import org.springframework.messaging.simp.stomp.StompHeaders
 import org.springframework.messaging.simp.stomp.StompSession
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.socket.client.standard.StandardWebSocketClient
 import org.springframework.web.socket.messaging.WebSocketStompClient
+import yjh.cstar.IntegrationTest
 
-@ActiveProfiles("local-test")
 @DisplayName("[Chat 테스트] Chat 연결 테스트")
-@SpringBootTest
-class ChatTest {
+class ChatTest : IntegrationTest() {
 
     /**
      * 웹소켓 연결 할 서버가 켜져있지 않으면(8080) 동작하지 않는 테스트이므로 @Disabled 처리를 해주었습니다.

--- a/src/test/kotlin/yjh/cstar/chat/application/PlayerAnswerSendServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/chat/application/PlayerAnswerSendServiceTest.kt
@@ -1,19 +1,13 @@
 package yjh.cstar.chat.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
+import org.springframework.transaction.annotation.Transactional
+import yjh.cstar.IntegrationTest
 import yjh.cstar.chat.domain.PlayerAnswer
 import yjh.cstar.chat.infrastructure.RedisAnswerMessageBroker
 import yjh.cstar.util.RedisUtil
@@ -21,10 +15,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
-@ActiveProfiles("local-test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
 @DisplayName("[Application 테스트] PlayerAnswerSendService")
-class PlayerAnswerSendServiceTest {
+class PlayerAnswerSendServiceTest : IntegrationTest() {
 
     @Autowired
     private lateinit var redisUtil: RedisUtil
@@ -42,29 +35,6 @@ class PlayerAnswerSendServiceTest {
         private const val ROOM_ID = 1L
         private const val QUIZ_ID = 1L
         private val KEY = RedisAnswerMessageBroker.getKey(ROOM_ID, QUIZ_ID)
-
-        private val redis: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:latest"))
-            .withExposedPorts(6379)
-            .withReuse(true)
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.data.redis.host", redis::getHost)
-            registry.add("spring.data.redis.port", redis::getFirstMappedPort)
-        }
-
-        @BeforeAll
-        @JvmStatic
-        fun beforeAll() {
-            redis.start()
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun afterAll() {
-            redis.stop()
-        }
     }
 
     @BeforeTest

--- a/src/test/kotlin/yjh/cstar/game/application/GameResultServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/game/application/GameResultServiceTest.kt
@@ -3,6 +3,7 @@ package yjh.cstar.game.application
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 import yjh.cstar.IntegrationTest
 import yjh.cstar.game.domain.GameResultCreateCommand
 import yjh.cstar.game.infrastructure.jpa.GameJpaRepository
@@ -13,6 +14,7 @@ import yjh.cstar.room.infrastructure.jpa.RoomJpaRepository
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
+@Transactional
 @DisplayName("[Application 테스트] GameResultService")
 class GameResultServiceTest : IntegrationTest() {
 

--- a/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
+++ b/src/test/kotlin/yjh/cstar/jpa/JpaTest.kt
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
-import yjh.cstar.config.JpaConfig
+import org.springframework.transaction.annotation.Transactional
+import yjh.cstar.IntegrationTest
 import yjh.cstar.game.infrastructure.jpa.GameEntity
 import yjh.cstar.game.infrastructure.jpa.GameJpaRepository
 import yjh.cstar.game.infrastructure.jpa.GameResultEntity
@@ -29,11 +27,9 @@ import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-@ActiveProfiles("local-test")
+@Transactional
 @DisplayName("[Infrastructure 테스트] JPA 연결 테스트")
-@Import(JpaConfig::class)
-@DataJpaTest
-class JpaTest {
+class JpaTest : IntegrationTest() {
 
     @Autowired
     private lateinit var memberJpaRepository: MemberJpaRepository

--- a/src/test/kotlin/yjh/cstar/member/application/MemberServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/member/application/MemberServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
 import yjh.cstar.IntegrationTest
 import yjh.cstar.common.BaseException
 import yjh.cstar.member.domain.MemberCreateCommand
@@ -17,6 +18,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Transactional
 @DisplayName("[Application 테스트] MemberService")
 class MemberServiceTest : IntegrationTest() {
 

--- a/src/test/kotlin/yjh/cstar/member/concurrency/MemberConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/member/concurrency/MemberConcurrencyTest.kt
@@ -3,8 +3,7 @@ package yjh.cstar.member.concurrency
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import yjh.cstar.IntegrationTest
 import yjh.cstar.member.application.MemberService
 import yjh.cstar.member.domain.MemberCreateCommand
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
@@ -20,9 +19,7 @@ import kotlin.test.assertEquals
  * @Transactional 를 사용하지 않아야 함(사용하면 올바르게 동작하지 않음)
  */
 @DisplayName("[동시성 테스트] MemberService")
-@ActiveProfiles("local-test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class MemberConcurrencyTest {
+class MemberConcurrencyTest : IntegrationTest() {
 
     @Autowired
     private lateinit var memberService: MemberService

--- a/src/test/kotlin/yjh/cstar/quiz/application/QuizServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/quiz/application/QuizServiceTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
 import yjh.cstar.IntegrationTest
 import yjh.cstar.category.domain.CategoryType
 import yjh.cstar.category.infrastructure.jpa.CategoryEntity
@@ -28,6 +29,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Transactional
 @DisplayName("[Application 테스트] QuizService")
 class QuizServiceTest : IntegrationTest() {
 

--- a/src/test/kotlin/yjh/cstar/redis/RedisConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/redis/RedisConcurrencyTest.kt
@@ -1,16 +1,9 @@
 package yjh.cstar.redis
 
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
+import yjh.cstar.IntegrationTest
 import yjh.cstar.chat.application.PlayerAnswerSendService
 import yjh.cstar.chat.infrastructure.RedisAnswerMessageBroker
 import yjh.cstar.play.domain.player.PlayerAnswer
@@ -24,10 +17,8 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
-@ActiveProfiles("local-test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DisplayName("[Redis 동시성 테스트] RedisConcurrency")
-class RedisConcurrencyTest {
+class RedisConcurrencyTest : IntegrationTest() {
 
     @Autowired
     private lateinit var playerAnswerSendService: PlayerAnswerSendService
@@ -42,29 +33,6 @@ class RedisConcurrencyTest {
         private const val ROOM_ID = 1L
         private const val QUIZ_ID = 1L
         private val KEY = RedisAnswerMessageBroker.getKey(ROOM_ID, QUIZ_ID)
-
-        private val redis: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:latest"))
-            .withExposedPorts(6379)
-            .withReuse(true)
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.data.redis.host", redis::getHost)
-            registry.add("spring.data.redis.port", redis::getFirstMappedPort)
-        }
-
-        @BeforeAll
-        @JvmStatic
-        fun beforeAll() {
-            redis.start()
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun afterAll() {
-            redis.stop()
-        }
     }
 
     @BeforeTest

--- a/src/test/kotlin/yjh/cstar/redis/RedisTest.kt
+++ b/src/test/kotlin/yjh/cstar/redis/RedisTest.kt
@@ -1,18 +1,11 @@
 package yjh.cstar.redis
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
+import yjh.cstar.IntegrationTest
 import yjh.cstar.chat.infrastructure.RedisAnswerMessageBroker
 import yjh.cstar.play.infrastructure.redis.PlayerAnswerEntity
 import yjh.cstar.util.RedisUtil
@@ -22,10 +15,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
-@ActiveProfiles("local-test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DisplayName("[Redis 테스트] Redis")
-class RedisTest {
+class RedisTest : IntegrationTest() {
 
     @Autowired
     private lateinit var redisTemplate: RedisTemplate<String, String>
@@ -40,29 +31,6 @@ class RedisTest {
         private const val ROOM_ID = 1L
         private const val QUIZ_ID = 1L
         private val KEY = RedisAnswerMessageBroker.getKey(ROOM_ID, QUIZ_ID)
-
-        private val redis: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:latest"))
-            .withExposedPorts(6379)
-            .withReuse(true)
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.data.redis.host", redis::getHost)
-            registry.add("spring.data.redis.port", redis::getFirstMappedPort)
-        }
-
-        @BeforeAll
-        @JvmStatic
-        fun beforeAll() {
-            redis.start()
-        }
-
-        @AfterAll
-        @JvmStatic
-        fun afterAll() {
-            redis.stop()
-        }
     }
 
     @BeforeTest

--- a/src/test/kotlin/yjh/cstar/room/application/RoomServiceTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/application/RoomServiceTest.kt
@@ -3,6 +3,7 @@ package yjh.cstar.room.application
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
 import yjh.cstar.IntegrationTest
 import yjh.cstar.common.BaseErrorCode
 import yjh.cstar.common.BaseException
@@ -21,6 +22,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Transactional
 @DisplayName("[Application 테스트] RoomService")
 class RoomServiceTest : IntegrationTest() {
 

--- a/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
+++ b/src/test/kotlin/yjh/cstar/room/concurrency/RoomConcurrencyTest.kt
@@ -3,8 +3,7 @@ package yjh.cstar.room.concurrency
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import yjh.cstar.IntegrationTest
 import yjh.cstar.auth.jwt.TokenProvider
 import yjh.cstar.member.infrastructure.jpa.MemberEntity
 import yjh.cstar.member.infrastructure.jpa.MemberJpaRepository
@@ -22,9 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 @DisplayName("[동시성 테스트] RoomConcurrency")
-@ActiveProfiles("local-test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class RoomConcurrencyTest {
+class RoomConcurrencyTest : IntegrationTest() {
 
     @Autowired
     private lateinit var roomController: RoomController

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -1,11 +1,10 @@
 spring:
   datasource:
-    url: jdbc:tc:mysql:8.0.35:///?useSSL=false&serverTimezone=Asia/Seoul
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # datasource 정보는 ApplicationContext 로드시 동적으로 주입
   data:
     redis:
-      host: test_container # 임의의 호스트명
-      port: 9999 # 임의의 포트번호
+      # redis 정보는 ApplicationContext 로드시 동적으로 주입
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## #️⃣ 관련 이슈
- ex) #130 

## 📝 작업한 내용
- [x] 테스트 컨테이너를 싱글톤으로 활용하도록 수정(전체 테스트에서 같은 컨테이너를 사용한다)
- [x] ApplicationContext를 재활용하기 위해 `@DataJpaTest` -> `@SpringBootTest` 로 변경 

## 💬 논의하고 싶은 내용
- 전체 테스트 시작전 MySQL 과 Redis 컨테이너를 구동시킨 후, 모든 테스트가 테스트 컨테이너를 사용하여 테스트를 수행한다.
- 각 테스트클래스는 테스트 수행 후 적절히 clear 작업을 수행해야한다.
ex) MySQL DB 작업 ->  `@Transactional`
ex) redis 작업 -> 직접 delete
ex) 동시성 테스트 -> 직접 delete
